### PR TITLE
Update `artisan` typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ composer install
 ```
 
 ```
-php artisal migrate
+php artisan migrate
 ```
 
 ```


### PR DESCRIPTION
- Fixed a typo in the README related to running `php artisan migrate`